### PR TITLE
Handles dollars sign in eyes or tongue

### DIFF
--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -24,7 +24,7 @@ module.exports = function (cow, variables) {
  *
  * cowsay -e "\$\$" Moo!
  */
-function escapeRe(s) {
+function escapeRe (s) {
 	if (s && s.replace) {
 		return s.replace(/\$/g, "$$$$");
 	}

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -1,15 +1,34 @@
 module.exports = function (cow, variables) {
+	var eyes = escapeRe(variables.eyes);
+	var tongue = escapeRe(variables.tongue);
+
 	if (cow.indexOf("$the_cow") !== -1) {
 		cow = extractTheCow(cow);
 	}
 
 	return cow
 		.replace(/\$thoughts/g, variables.thoughts)
-		.replace(/\$eyes/g, variables.eyes)
-		.replace(/\$tongue/g, variables.tongue)
-		.replace(/\$\{eyes\}/g, variables.eyes)
-		.replace(/\$\{tongue\}/g, variables.tongue)
+		.replace(/\$eyes/g, eyes)
+		.replace(/\$tongue/g, tongue)
+		.replace(/\$\{eyes\}/g, eyes)
+		.replace(/\$\{tongue\}/g, tongue)
 	;
+};
+
+/*
+ * "$" dollar signs must be doubled before being used in a regex replace
+ * This can occur in eyes or tongue.
+ * For example:
+ *
+ * cowsay -g Moo!
+ *
+ * cowsay -e "\$\$" Moo!
+ */
+function escapeRe(s) {
+	if (s && s.replace) {
+		return s.replace(/\$/g, "$$$$");
+	}
+	return s;
 }
 
 function extractTheCow (cow) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "optimist": "~0.3.5"
   },
   "devDependencies": {
-    "nodeunit": "~0.7.4"
+    "nodeunit": "~0.9.1"
   },
   "preferGlobal": true
 }


### PR DESCRIPTION
Hi there - I just ported cowsay to Java and was comparing the output against your version as well as the original. I noticed yours is not handling greedy mode or dollars signs in general for the eyes or tongue. 

Here's a patch to fix it.

`cowsay -g Moo!`

Before 
```
 ______
< Moo! >
 ------
        \   ^__^
         \  ($)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

After
```
 ______
< Moo! >
 ------
        \   ^__^
         \  ($$)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```