### PR TITLE
Use simple cache for cow file contents

### DIFF
--- a/lib/cows.js
+++ b/lib/cows.js
@@ -2,15 +2,21 @@ var path = require("path");
 var fs = require("fs");
 var replacer = require("./replacer");
 
-exports.get = function (cow) {
-	var filePath;
-	if (cow.indexOf("/") === -1) {
-		filePath = path.join(__dirname, "/../cows", cow) + ".cow";
-	} else {
-		filePath = path.relative(process.cwd(), cow);
-	}
+var textCache = {};
 
-	var text = fs.readFileSync(filePath, "utf-8");
+exports.get = function (cow) {
+	var text = textCache[cow];
+
+	if (!text) {
+		var filePath;
+		if (cow.indexOf("/") === -1) {
+			filePath = path.join(__dirname, "/../cows", cow) + ".cow";
+		} else {
+			filePath = path.relative(process.cwd(), cow);
+		}
+		text = fs.readFileSync(filePath, "utf-8");
+		textCache[cow] = text;
+	}
 
 	return function (options) {
 		return replacer(text, options);


### PR DESCRIPTION
This prevents the filesystem being accessed every time when the same cow type is used multiple times. Important for applications that need to generate many cows and care about performance.