### PR TITLE
Add `files` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "cowsay": "./cli.js",
     "cowthink": "./cli.js"
   },
+  "files": [
+    "index.js",
+    "cli.js",
+    "cows/",
+    "lib/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/piuccio/cowsay.git"


### PR DESCRIPTION
This way, users who install this module don't have to download irrelevant stuff like the test directory.