### PR TITLE
Add get-stdin back to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test": "node test.js"
   },
   "dependencies": {
+    "get-stdin": "^4.0.1",
     "optimist": "~0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds v4 of `get-stdin` back to the list of dependencies in order to fix the support for piping input from the command line to `cowsay` (eg. `fortune | cowsay`). This is just a hot fix that uses the version of `get-stdin` when the piping feature was implemented here: dea942e1da42cb4fcf0fb306fcb95fe0b52a6b19. It was removed with 9b11ea61e44bbe7713d961322eb66e915eed7e57 when bumping to new versions of `optimist` and `nodeunit`.

