### PR TITLE
Correctly handle tab characters in the input.

### DIFF
--- a/lib/balloon.js
+++ b/lib/balloon.js
@@ -57,7 +57,7 @@ function format (text, wrap, delimiters) {
 }
 
 function split (text, wrap) {
-	text = text.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, '');
+	text = text.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, '').replace(/\t/g, '        ');
 
 	var lines = [];
 	if (!wrap) {


### PR DESCRIPTION
Tabs are replaced with 8 spaces. Custom tab-width option may be added later.
This ensures the max line length is calculated correctly and the border is
sized appropriately.

Fixes #12 
To test, execute with bash:
`echo $'aaaaaaa\n\t\tbbb' | cowsay`
