### PR TITLE
Provided for Windows pathname

### DIFF
--- a/lib/cows.js
+++ b/lib/cows.js
@@ -9,10 +9,11 @@ exports.get = function (cow) {
 
 	if (!text) {
 		var filePath;
-		if (cow.indexOf("/") === -1) {
-			filePath = path.join(__dirname, "/../cows", cow) + ".cow";
+
+		if (cow.match(/\\/) || cow.match(/\//)) {
+			filePath = cow;
 		} else {
-			filePath = path.relative(process.cwd(), cow);
+			filePath = path.join(__dirname, "/../cows", cow) + ".cow";
 		}
 		text = fs.readFileSync(filePath, "utf-8");
 		textCache[cow] = text;


### PR DESCRIPTION
In `lib/cows.js`, we're only checking for a Unix path delimiter when someone is supplying the option for their cowsay character.