### PR TITLE
Fix #28 by stripping the trailing new line

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -46,7 +46,7 @@ if (argv.l) {
 } else {
 	require("get-stdin")().then(function (data) {
 		if (data) {
-			argv._ = [data];
+			argv._ = [require("strip-eof")(data)];
 			say();
 		} else {
 			showHelp();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "get-stdin": "^5.0.1",
     "optimist": "~0.6.1",
-    "string-width": "~2.1.1"
+    "string-width": "~2.1.1",
+    "strip-eof": "^1.0.0"
   },
   "devDependencies": {
     "nodeunit": "~0.11.1",


### PR DESCRIPTION
According to get-stdin author, [the trailing new line produced by `echo` is expected](https://github.com/sindresorhus/get-stdin/issues/22).

He recommends using [strip-eof](https://github.com/sindresorhus/strip-eof) to remove it, which is what I did in this PR.

Edit: If my understanding is correct, the Perl version [uses `chomp` for the same effect](https://github.com/tnalpgge/rank-amateur-cowsay/blob/99058032db7cafbc507a3fbe8cae6be2d9f65ee3/cowsay#L95).

Thanks!