### PR TITLE
Added additional parameter check for a sole string passed to the say/think method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ console.log(cowsay.say({
                 ||     ||
 ````
 
+you can also use the shorthand version by passing text to the function
+
+```js
+const cowsay = require("cowsay");
+
+console.log(cowsay.say("I'm a moooodule"));
+
+// or cowsay.think()
+```
+
 getting a list of cow names:
 ```js
 function get_cows(error, cow_names) {

--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ var faces = require("./lib/faces");
  *     text: 'Hello world!',
  *     y: true, // using y mode - youthful mode
  * })
+ *
+ * // shorthand
+ * cowsay.say("Hello world!")
  * ```
  * 
  * @returns {string} compiled cow
@@ -104,6 +107,9 @@ exports.say = function (options) {
  *     text: 'Hello world!',
  *     y: true, // using y mode - youthful mode
  * })
+ *
+ * // shorthand
+ * cowsay.think("Hello world!")
  * ```
  * 
  * @returns {string} compiled cow
@@ -133,6 +139,10 @@ exports.list = cows.list;
 
 function doIt (options, sayAloud) {
 	var cowFile;
+
+	if (typeof options === 'string') {
+		options = { text: options };
+	}
 
 	if (options.r) {
 		var cowsList = cows.listSync();


### PR DESCRIPTION
…all the default cow

Related Issue: https://github.com/piuccio/cowsay/issues/76

From the related issue, I simply added a check to the input to see if it is a string passed instead of proper options and print out the default cow saying the string. Also added a small edit showcasing the shorthand version in the README.